### PR TITLE
Add CrewAI card creation assistant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+.env

--- a/README.md
+++ b/README.md
@@ -1,1 +1,67 @@
-# crewai
+# CrewAI Card Creator
+
+Yeh project CrewAI ka use karke ek interactive agentic system banata hai jo kisi bhi occasion ke liye beautiful card design blueprint ready karta hai. System Hindi + English tone mein user se smart questions karta hai, jab tak sari zaroori details collect na ho jayein. Core information jo hamisha collect hoti hai:
+
+1. Occasion kis ke liye hai
+2. Card personal hai ya business
+3. Card ka size kya hai
+
+Iske baad assistant additional context jaise tone, colors, imagery, deadlines wagairah poochta hai. Agar user koi image URL share karta hai to woh final blueprint mein **must-use** assets ke taur par lock ho jata hai. Background inspiration ke liye Pexels API ka istemal kiya ja sakta hai.
+
+## Features
+
+- Rule-based requirement interview jo ensure karta hai ki core fields kabhi skip na hon.
+- Automatic URL detection jisse user provided images secure rahte hain.
+- CrewAI based multi-agent workflow jo creative brief aur final card blueprint (JSON format) generate karta hai.
+- Pexels API integration se background inspiration fetch karta hai.
+- Rich + Typer CLI experience for an interactive chatbot style flow.
+
+## Installation
+
+```bash
+pip install -e .
+```
+
+Ya phir virtual environment setup karke `pip install -e .[dev]` run karein agar tests bhi execute karne hain.
+
+## Environment variables
+
+System ko run karne se pehle neeche wali keys configure karein (real values use karein):
+
+```bash
+export OPENAI_API_KEY="..."
+# ya agar SambaNova prefer karna ho to
+# export CARD_CREW_PROVIDER="sambanova"
+# export SAMBANOVA_API_KEY="..."
+
+export PEXELS_API_KEY="..."
+```
+
+Aap `CARD_CREW_MODEL`, `CARD_CREW_TEMPERATURE` wagairah optional overrides bhi set kar sakte hain.
+
+## Usage
+
+Interactive chat start karne ke liye:
+
+```bash
+card-crew chat
+```
+
+Ya phir:
+
+```bash
+python -m card_creator.cli chat
+```
+
+CLI aap se step-by-step sawaal puchega. Jab aapko lage ki sab details mil gayi hain to `done` likh kar blueprint generation trigger karein.
+
+## Tests
+
+```bash
+pytest
+```
+
+## Notes
+
+- Project network calls (OpenAI/SambaNova/Pexels) tabhi chalenge jab valid API keys aur internet connectivity present ho.
+- Agar LLM se JSON response parse na ho paye to raw text CLI mein display ho jayega.

--- a/card_creator/__init__.py
+++ b/card_creator/__init__.py
@@ -1,0 +1,21 @@
+"""Card creation crew package."""
+
+from __future__ import annotations
+
+from .config import Settings
+from .requirements import CardRequirements, RequirementManager
+
+__all__ = [
+    "Settings",
+    "CardRequirements",
+    "RequirementManager",
+    "CardDesignCrew",
+]
+
+
+def __getattr__(name: str):  # pragma: no cover - simple lazy import hook
+    if name == "CardDesignCrew":
+        from .crew import CardDesignCrew
+
+        return CardDesignCrew
+    raise AttributeError(name)

--- a/card_creator/cli.py
+++ b/card_creator/cli.py
@@ -1,0 +1,96 @@
+"""Command line interface for the card creation crew."""
+from __future__ import annotations
+
+import json
+
+import typer
+from rich.console import Console
+from rich.prompt import Prompt
+from rich.table import Table
+
+from .config import Settings
+from .crew import CardDesignCrew
+from .requirements import RequirementManager
+
+app = typer.Typer(help="Interactive assistant for designing bespoke cards.")
+
+
+@app.command()
+def chat() -> None:
+    """Start an interactive chat to collect requirements and design a card."""
+
+    console = Console()
+    manager = RequirementManager()
+    welcome = manager.welcome()
+    if welcome:
+        console.print(f"[bold green]{welcome}[/bold green]")
+
+    question = manager.next_question()
+    while question:
+        console.print(f"\n[bold cyan]{question}[/bold cyan]")
+        answer = Prompt.ask("Aapka jawab")
+        normalized = answer.strip().lower()
+        if normalized in {"done", "design banao", "design shuru karo", "generate"}:
+            if manager.requirements.is_core_complete():
+                console.print("Theek hai! Main ab tak ki details ke basis par design banaata hoon.")
+                break
+            missing = ", ".join(manager.requirements.required_fields_missing())
+            console.print(
+                f"[red]Abhi yeh important cheezein missing hain: {missing}. Pehle inhe share karein.[/red]"
+            )
+            continue
+        manager.ingest_answer(answer)
+        question = manager.next_question()
+
+    if not manager.requirements.is_core_complete():
+        console.print(
+            "[bold red]Card design shuru karne se pehle occasion, card type aur size zaroori hain.[/bold red]"
+        )
+        return
+
+    console.print("\n[bold]Yeh hai ab tak ka summary:[/bold]")
+    console.print(manager.summary())
+
+    if not typer.confirm("Kya aap chahte hain ki main card blueprint generate karu?", default=True):
+        console.print("Thik hai! Aap kabhi bhi dubara run kar sakte hain.")
+        return
+
+    settings = Settings()
+    try:
+        crew = CardDesignCrew(settings, manager.requirements)
+        result = crew.run()
+    except ValueError as exc:
+        console.print(f"[bold red]Configuration error:[/bold red] {exc}")
+        console.print(
+            "Kripya environment variables set karein: OPENAI_API_KEY ya SAMBANOVA_API_KEY aur PEXELS_API_KEY."
+        )
+        raise typer.Exit(code=1) from exc
+    except Exception as exc:  # pragma: no cover - defensive guard for runtime issues
+        console.print(f"[bold red]Crew execution failed:[/bold red] {exc}")
+        raise typer.Exit(code=1) from exc
+
+    blueprint = result.get("blueprint")
+    if blueprint:
+        console.print("\n[bold green]Card Blueprint Ready![/bold green]")
+        console.print(json.dumps(blueprint, indent=2, ensure_ascii=False))
+    else:
+        console.print("\n[bold yellow]LLM se JSON parse nahi ho paya. Raw response neeche diya gaya hai:[/bold yellow]")
+        console.print(result.get("raw_output"))
+
+    inspirations = result.get("pexels_images", [])
+    if inspirations:
+        console.print("\n[bold]Inspiring backgrounds from Pexels:[/bold]")
+        table = Table("Preview", "Photographer", "Avg. Color")
+        for photo in inspirations:
+            table.add_row(photo.get("image_url", ""), photo.get("photographer", ""), photo.get("avg_color", ""))
+        console.print(table)
+
+
+def run() -> None:
+    """Entry point used by ``python -m card_creator.cli``."""
+
+    app()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    run()

--- a/card_creator/config.py
+++ b/card_creator/config.py
@@ -1,0 +1,54 @@
+"""Configuration helpers for the card creator crew."""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+
+
+@dataclass(slots=True)
+class Settings:
+    """Runtime configuration for the card creation system."""
+
+    openai_api_key: str | None = field(default_factory=lambda: os.getenv("OPENAI_API_KEY"))
+    sambanova_api_key: str | None = field(default_factory=lambda: os.getenv("SAMBANOVA_API_KEY"))
+    pexels_api_key: str | None = field(default_factory=lambda: os.getenv("PEXELS_API_KEY"))
+    model: str = field(default_factory=lambda: os.getenv("CARD_CREW_MODEL", "gpt-4o-mini"))
+    provider: str = field(default_factory=lambda: os.getenv("CARD_CREW_PROVIDER", "openai"))
+    organization: str | None = field(default_factory=lambda: os.getenv("OPENAI_ORG"))
+    temperature: float = field(default_factory=lambda: float(os.getenv("CARD_CREW_TEMPERATURE", "0.4")))
+
+    def ensure_llm_credentials(self) -> None:
+        """Validate that we have credentials for the selected provider."""
+
+        if self.provider == "openai" and not self.openai_api_key:
+            raise ValueError(
+                "OPENAI_API_KEY is required when provider is set to 'openai'."
+            )
+        if self.provider == "sambanova" and not self.sambanova_api_key:
+            raise ValueError(
+                "SAMBANOVA_API_KEY is required when provider is set to 'sambanova'."
+            )
+
+    def llm_arguments(self) -> dict[str, object]:
+        """Return keyword arguments to construct a :class:`crewai.llm.LLM`."""
+
+        self.ensure_llm_credentials()
+        kwargs: dict[str, object] = {
+            "model": self.model,
+            "temperature": self.temperature,
+        }
+        if self.provider == "openai":
+            kwargs["api_key"] = self.openai_api_key
+            if self.organization:
+                kwargs["organization"] = self.organization
+        elif self.provider == "sambanova":
+            kwargs["api_key"] = self.sambanova_api_key
+            kwargs["base_url"] = os.getenv(
+                "SAMBANOVA_BASE_URL", "https://api.sambanova.ai/v1"
+            )
+        else:
+            raise ValueError(f"Unsupported provider: {self.provider}")
+        return kwargs
+
+
+__all__ = ["Settings"]

--- a/card_creator/crew.py
+++ b/card_creator/crew.py
@@ -1,0 +1,145 @@
+"""Crew orchestration for creating a polished card blueprint."""
+from __future__ import annotations
+
+import json
+from dataclasses import asdict
+from textwrap import dedent
+from typing import Any
+
+from crewai import Agent, Crew, Process, Task
+from crewai.llm import LLM
+
+from .config import Settings
+from .pexels import PexelsPhoto, search_backgrounds
+from .requirements import CardRequirements
+
+
+class CardDesignCrew:
+    """Coordinates specialist agents to design a card blueprint."""
+
+    def __init__(self, settings: Settings, requirements: CardRequirements) -> None:
+        self.settings = settings
+        self.requirements = requirements
+        self._llm = LLM(**self.settings.llm_arguments())
+        self._pexels_images: list[PexelsPhoto] = []
+
+    def gather_inspirations(self) -> list[PexelsPhoto]:
+        """Collect relevant Pexels images based on the requirement set."""
+
+        if not self._pexels_images:
+            query = self.requirements.build_pexels_query()
+            self._pexels_images = search_backgrounds(
+                self.settings.pexels_api_key,
+                query,
+                per_page=6,
+                orientation="landscape",
+            )
+        return self._pexels_images
+
+    def run(self) -> dict[str, Any]:
+        """Execute the crew and return a structured blueprint."""
+
+        inspirations = [asdict(photo) for photo in self.gather_inspirations()]
+        requirement_summary = self.requirements.to_summary_dict()
+        requirement_summary["pexels_inspirations"] = inspirations
+
+        planner = Agent(
+            name="Requirement Analyst",
+            role="Understand user goals and distil them into a creative brief.",
+            goal="Transform user requirements into a sharp design direction for a card.",
+            backstory=dedent(
+                """
+                Tum ek experienced design strategist ho jo card design projects ko
+                structure karta hai. Tumhe ensure karna hai ki har requirement clearly
+                defined ho aur koi bhi missing detail highlight ho sake.
+                """
+            ),
+            llm=self._llm,
+        )
+
+        copywriter = Agent(
+            name="Copywriter & Layout Specialist",
+            role="Craft heartfelt copy and propose card layouts based on the brief.",
+            goal="Deliver a final blueprint with messaging, layout and imagery guidance.",
+            backstory=dedent(
+                """
+                Tum ek award-winning card designer ho jo typography aur layout ko bahut
+                achhi tarah balance karta hai. Tumhe ensure karna hai ki final blueprint
+                mein user ke diye gaye images zaroor shamil hon aur occasion ke hisaab se
+                tone perfect ho.
+                """
+            ),
+            llm=self._llm,
+        )
+
+        analysis_task = Task(
+            description=dedent(
+                f"""
+                Neeche card project ki sari details di gayi hain:
+                ```json
+                {json.dumps(requirement_summary, indent=2, ensure_ascii=False)}
+                ```
+
+                Tumhara kaam hai ek concise creative brief banana jo card ke goals,
+                target audience aur critical constraints ko summarise kare. Agar koi
+                important information missing ho to usse list karo.
+
+                Output ko JSON mein do with fields: "brief", "gaps".
+                """
+            ),
+            expected_output="JSON with keys 'brief' aur 'gaps'.",
+            agent=planner,
+        )
+
+        final_task = Task(
+            description=dedent(
+                """
+                Tumhe Requirement Analyst ka brief aur sari project details mil gayi hain.
+                Ab tumhara kaam hai poora card blueprint ready karna.
+
+                Deliverables ko JSON object ki tarah present karo with keys:
+                - "card_summary": short overview of the concept.
+                - "messaging":
+                    - "headline"
+                    - "body"
+                    - "closing"
+                - "visual_direction":
+                    - "palette"
+                    - "typography"
+                    - "layout"
+                    - "background_image_plan"
+                - "image_assets": "must_use" (sab user provided URLs) aur "pexels_options" (top 3 inspirations).
+                - "production_notes": kisi bhi printing ya export ke instructions.
+                - "next_questions": agar koi detail abhi bhi missing hai to unhe list karo.
+
+                Har hal mein user dwara diye gaye saare image URLs "must_use" mein hon.
+                Background_image_plan mein bataye kaunse visuals kis tarah se use honge.
+                """
+            ),
+            expected_output="Structured JSON blueprint jisme sab sections bharay hon.",
+            agent=copywriter,
+        )
+
+        crew = Crew(
+            agents=[planner, copywriter],
+            tasks=[analysis_task, final_task],
+            process=Process.sequential,
+            verbose=False,
+        )
+
+        result = crew.run()
+        blueprint = self._safe_parse_json(result)
+        return {
+            "raw_output": result,
+            "blueprint": blueprint,
+            "pexels_images": inspirations,
+        }
+
+    def _safe_parse_json(self, payload: str) -> dict[str, Any] | None:
+        try:
+            return json.loads(payload)
+        except (TypeError, json.JSONDecodeError):
+            return None
+
+
+__all__ = ["CardDesignCrew"]

--- a/card_creator/pexels.py
+++ b/card_creator/pexels.py
@@ -1,0 +1,67 @@
+"""Pexels API integration for fetching inspirational card backgrounds."""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+import requests
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class PexelsPhoto:
+    """Simplified representation of a Pexels photo entry."""
+
+    id: int
+    url: str
+    photographer: str
+    photographer_url: str
+    image_url: str
+    avg_color: str | None = None
+
+
+def search_backgrounds(
+    api_key: str | None,
+    query: str,
+    *,
+    per_page: int = 5,
+    orientation: str = "landscape",
+) -> list[PexelsPhoto]:
+    """Search the Pexels API for backgrounds that match the provided query."""
+
+    if not api_key:
+        LOGGER.warning("No Pexels API key supplied; skipping image search.")
+        return []
+
+    url = "https://api.pexels.com/v1/search"
+    headers = {"Authorization": api_key}
+    params = {
+        "query": query,
+        "per_page": per_page,
+        "orientation": orientation,
+    }
+    try:
+        response = requests.get(url, headers=headers, params=params, timeout=15)
+        response.raise_for_status()
+    except requests.RequestException as exc:
+        LOGGER.error("Pexels API request failed: %s", exc)
+        return []
+
+    payload = response.json()
+    photos: list[PexelsPhoto] = []
+    for entry in payload.get("photos", []):
+        src = entry.get("src", {})
+        photos.append(
+            PexelsPhoto(
+                id=entry.get("id"),
+                url=entry.get("url"),
+                photographer=entry.get("photographer", ""),
+                photographer_url=entry.get("photographer_url", ""),
+                image_url=src.get("large2x") or src.get("original") or entry.get("url"),
+                avg_color=entry.get("avg_color"),
+            )
+        )
+    return photos
+
+
+__all__ = ["PexelsPhoto", "search_backgrounds"]

--- a/card_creator/requirements.py
+++ b/card_creator/requirements.py
@@ -1,0 +1,409 @@
+"""Requirement management for the card creation workflow."""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Callable, Optional
+
+
+URL_PATTERN = re.compile(r"https?://[^\s]+", re.IGNORECASE)
+
+
+@dataclass(slots=True)
+class CardRequirements:
+    """Structured representation of card requirements collected from the user."""
+
+    occasion: str | None = None
+    card_type: str | None = None
+    size: str | None = None
+    recipient: str | None = None
+    relationship: str | None = None
+    tone: str | None = None
+    message_focus: str | None = None
+    personalization_details: str | None = None
+    color_palette: str | None = None
+    typography: str | None = None
+    visual_style: str | None = None
+    must_include_elements: str | None = None
+    call_to_action: str | None = None
+    delivery_format: str | None = None
+    deadline: str | None = None
+    additional_notes: str | None = None
+    brand_notes: str | None = None
+    image_urls: list[str] = field(default_factory=list)
+
+    def required_fields_missing(self) -> list[str]:
+        """Return a list of required fields that are still missing."""
+
+        missing = []
+        if not self.occasion:
+            missing.append("occasion")
+        if not self.card_type:
+            missing.append("card_type")
+        if not self.size:
+            missing.append("size")
+        return missing
+
+    def is_core_complete(self) -> bool:
+        """Whether the three mandatory attributes are collected."""
+
+        return not self.required_fields_missing()
+
+    def to_summary_dict(self) -> dict[str, object]:
+        """Convert to a serialisable summary dictionary."""
+
+        return {
+            "occasion": self.occasion,
+            "card_type": self.card_type,
+            "size": self.size,
+            "recipient": self.recipient,
+            "relationship": self.relationship,
+            "tone": self.tone,
+            "message_focus": self.message_focus,
+            "personalization_details": self.personalization_details,
+            "color_palette": self.color_palette,
+            "typography": self.typography,
+            "visual_style": self.visual_style,
+            "must_include_elements": self.must_include_elements,
+            "call_to_action": self.call_to_action,
+            "delivery_format": self.delivery_format,
+            "deadline": self.deadline,
+            "additional_notes": self.additional_notes,
+            "brand_notes": self.brand_notes,
+            "image_urls": list(self.image_urls),
+        }
+
+    def build_pexels_query(self) -> str:
+        """Construct a default query for the Pexels search."""
+
+        keywords: list[str] = []
+        if self.occasion:
+            keywords.append(self.occasion)
+        if self.tone:
+            keywords.append(self.tone)
+        if self.color_palette:
+            keywords.append(self.color_palette)
+        if self.visual_style:
+            keywords.append(self.visual_style)
+        if not keywords:
+            keywords.append("beautiful card background")
+        return " ".join(keywords)
+
+
+@dataclass(slots=True)
+class Question:
+    """Represents a question that can be asked to the user."""
+
+    id: str
+    prompt_builder: Callable[[CardRequirements], str]
+    field: str | None = None
+    required: bool = False
+    handler: Optional[Callable[[CardRequirements, str], None]] = None
+    condition: Callable[[CardRequirements], bool] = lambda _: True
+
+    def render(self, requirements: CardRequirements) -> str:
+        return self.prompt_builder(requirements)
+
+    def apply_answer(self, requirements: CardRequirements, answer: str) -> None:
+        if self.handler is not None:
+            self.handler(requirements, answer)
+        elif self.field:
+            cleaned = URL_PATTERN.sub("", answer).strip()
+            setattr(requirements, self.field, cleaned or answer.strip())
+
+
+class RequirementManager:
+    """Stateful helper that drives the requirements interview."""
+
+    def __init__(self) -> None:
+        self.requirements = CardRequirements()
+        self._question_order: list[Question] = self._build_question_bank()
+        self._asked: set[str] = set()
+        self._active_question: Question | None = None
+        self._greeted = False
+
+    def _build_question_bank(self) -> list[Question]:
+        questions: list[Question] = [
+            Question(
+                id="occasion",
+                field="occasion",
+                required=True,
+                prompt_builder=lambda _: "Aap kis occasion ke liye card banana chahte hain?",
+            ),
+            Question(
+                id="card_type",
+                field="card_type",
+                required=True,
+                prompt_builder=lambda _: (
+                    "Kya yeh personal card hai ya business card? Agar business hai to brand/company ka"
+                    " naam bhi batayein."
+                ),
+            ),
+            Question(
+                id="size",
+                field="size",
+                required=True,
+                prompt_builder=lambda _: (
+                    "Card ka size kya rakhen? (jaise 5x7 inch, A5, ya koi digital format)"
+                ),
+            ),
+            Question(
+                id="recipient",
+                field="recipient",
+                prompt_builder=lambda req: (
+                    "Card kis ke liye hai? Agar naam ya relation bata sakein to behatar rahega."
+                ),
+            ),
+            Question(
+                id="relationship",
+                field="relationship",
+                prompt_builder=lambda req: (
+                    "Recipient se aapka relationship kya hai? (jaise friend, client, parents)"
+                ),
+            ),
+            Question(
+                id="tone",
+                field="tone",
+                prompt_builder=lambda req: (
+                    f"{req.occasion or 'Card'} ka tone kaise rakhna hai? (jaise elegant, fun, professional)"
+                ),
+            ),
+            Question(
+                id="message_focus",
+                field="message_focus",
+                prompt_builder=lambda req: (
+                    "Message ka main focus kya ho? koi keyword ya feeling jo zaroor include ho?"
+                ),
+            ),
+            Question(
+                id="personalization_details",
+                field="personalization_details",
+                prompt_builder=lambda req: (
+                    "Koi personal details ya inside jokes jo add karna chahte ho?"
+                ),
+            ),
+            Question(
+                id="color_palette",
+                field="color_palette",
+                prompt_builder=lambda req: (
+                    "Kis color palette ya combinations ko prefer karenge?"
+                ),
+            ),
+            Question(
+                id="typography",
+                field="typography",
+                prompt_builder=lambda req: (
+                    "Fonts kis type ke pasand karenge? (jaise handwritten, modern sans, serif)"
+                ),
+            ),
+            Question(
+                id="visual_style",
+                field="visual_style",
+                prompt_builder=lambda req: (
+                    "Background ya illustrations ka style kya ho? (minimal, floral, abstract, etc.)"
+                ),
+            ),
+            Question(
+                id="must_include_elements",
+                field="must_include_elements",
+                prompt_builder=lambda req: (
+                    "Koi elements ya phrases jo card par zaroor hone chahiye?"
+                ),
+            ),
+            Question(
+                id="call_to_action",
+                field="call_to_action",
+                prompt_builder=lambda req: (
+                    "Agar business card hai to koi call-to-action ya contact info batayein?"
+                ),
+                condition=lambda req: (req.card_type or "").lower().startswith("business"),
+            ),
+            Question(
+                id="brand_notes",
+                field="brand_notes",
+                prompt_builder=lambda req: (
+                    "Brand guidelines ya logo colors share karna chahenge?"
+                ),
+                condition=lambda req: (req.card_type or "").lower().startswith("business"),
+            ),
+            Question(
+                id="delivery_format",
+                field="delivery_format",
+                prompt_builder=lambda req: (
+                    "Card ka final format kya hoga? (print-ready PDF, social media post, etc.)"
+                ),
+            ),
+            Question(
+                id="deadline",
+                field="deadline",
+                prompt_builder=lambda req: (
+                    "Card kab tak ready chahiye? koi deadline ya event date?"
+                ),
+            ),
+            Question(
+                id="image_urls",
+                handler=self._handle_image_answer,
+                prompt_builder=lambda req: (
+                    "Kya aapke paas koi image ya logo URLs hain jo card mein lazmi hone chahiye?"
+                ),
+            ),
+            Question(
+                id="additional_notes",
+                field="additional_notes",
+                prompt_builder=lambda req: (
+                    "Koi aur special instruction ya note jo hume consider karna chahiye?"
+                ),
+            ),
+        ]
+        return questions
+
+    def _handle_image_answer(self, requirements: CardRequirements, answer: str) -> None:
+        urls = extract_urls(answer)
+        if urls:
+            for url in urls:
+                if url not in requirements.image_urls:
+                    requirements.image_urls.append(url)
+        if urls:
+            remaining = URL_PATTERN.sub("", answer).strip()
+            if remaining:
+                requirements.must_include_elements = merge_text(
+                    requirements.must_include_elements, remaining
+                )
+        elif answer.strip():
+            requirements.must_include_elements = merge_text(
+                requirements.must_include_elements, answer.strip()
+            )
+
+    def welcome(self) -> str:
+        if self._greeted:
+            return ""
+        self._greeted = True
+        return (
+            "Namaste! Main aapka card design assistant hoon. Kuch sawaalon se hum"
+            " ek perfect card banayenge. Aap kisi bhi waqt 'done' likh kar design"
+            " banwana start kar sakte hain jab aapko lage details complete ho gayi hain."
+        )
+
+    def next_question(self) -> str | None:
+        """Return the next question text that should be asked."""
+
+        # Prioritise mandatory fields
+        for question in self._question_order:
+            if question.required and getattr(self.requirements, question.field or "", None) in (None, ""):
+                if question.condition(self.requirements):
+                    self._active_question = question
+                    self._asked.add(question.id)
+                    return question.render(self.requirements)
+
+        for question in self._question_order:
+            if question.id in self._asked:
+                continue
+            if not question.condition(self.requirements):
+                continue
+            # Skip optional question if already filled via previous answer
+            if question.field and getattr(self.requirements, question.field, None):
+                continue
+            self._active_question = question
+            self._asked.add(question.id)
+            return question.render(self.requirements)
+
+        self._active_question = None
+        return None
+
+    def ingest_answer(self, answer: str) -> None:
+        """Store the answer for the current active question."""
+
+        answer = answer.strip()
+        if not answer:
+            return
+        self._capture_urls(answer)
+        if not self._active_question:
+            return
+        self._active_question.apply_answer(self.requirements, answer)
+
+    def _capture_urls(self, message: str) -> None:
+        urls = extract_urls(message)
+        if not urls:
+            return
+        for url in urls:
+            if url not in self.requirements.image_urls:
+                self.requirements.image_urls.append(url)
+
+    def summary(self) -> str:
+        """Return a readable summary of captured requirements."""
+
+        parts = [
+            "Collected requirements:",
+            f"  Occasion: {self.requirements.occasion or '—'}",
+            f"  Card type: {self.requirements.card_type or '—'}",
+            f"  Size: {self.requirements.size or '—'}",
+        ]
+        optional_fields = {
+            "Recipient": self.requirements.recipient,
+            "Relationship": self.requirements.relationship,
+            "Tone": self.requirements.tone,
+            "Message focus": self.requirements.message_focus,
+            "Personal details": self.requirements.personalization_details,
+            "Color palette": self.requirements.color_palette,
+            "Typography": self.requirements.typography,
+            "Visual style": self.requirements.visual_style,
+            "Must include": self.requirements.must_include_elements,
+            "Call to action": self.requirements.call_to_action,
+            "Delivery format": self.requirements.delivery_format,
+            "Deadline": self.requirements.deadline,
+            "Additional notes": self.requirements.additional_notes,
+            "Brand notes": self.requirements.brand_notes,
+        }
+        for label, value in optional_fields.items():
+            if value:
+                parts.append(f"  {label}: {value}")
+        if self.requirements.image_urls:
+            parts.append("  Image URLs:")
+            for url in self.requirements.image_urls:
+                parts.append(f"    - {url}")
+        return "\n".join(parts)
+
+    def has_more_questions(self) -> bool:
+        """Whether there are more relevant questions to ask."""
+
+        if any(
+            question.required
+            and getattr(self.requirements, question.field or "", None) in (None, "")
+            and question.condition(self.requirements)
+            for question in self._question_order
+        ):
+            return True
+        for question in self._question_order:
+            if question.id in self._asked:
+                continue
+            if not question.condition(self.requirements):
+                continue
+            if question.field and getattr(self.requirements, question.field, None):
+                continue
+            return True
+        return False
+
+
+def extract_urls(text: str) -> list[str]:
+    """Extract URLs from the given text."""
+
+    return URL_PATTERN.findall(text)
+
+
+def merge_text(existing: str | None, addition: str) -> str:
+    """Merge new text into an existing optional field."""
+
+    if not existing:
+        return addition
+    if addition.lower() in existing.lower():
+        return existing
+    return f"{existing}; {addition}"
+
+
+__all__ = [
+    "CardRequirements",
+    "RequirementManager",
+    "Question",
+    "extract_urls",
+    "merge_text",
+]

--- a/main.py
+++ b/main.py
@@ -1,0 +1,6 @@
+"""Entry point for launching the card creator CLI."""
+from card_creator.cli import run
+
+
+if __name__ == "__main__":
+    run()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,24 @@
+[project]
+name = "card-creator"
+version = "0.1.0"
+description = "CrewAI powered assistant for designing cards for any occasion."
+authors = [{ name = "AI Assistant" }]
+requires-python = ">=3.10"
+dependencies = [
+  "crewai>=0.51.0",
+  "typer>=0.12.3",
+  "rich>=13.7.1",
+  "requests>=2.31.0",
+]
+
+[project.optional-dependencies]
+dev = [
+  "pytest>=8.2.0",
+]
+
+[project.scripts]
+card-crew = "card_creator.cli:run"
+
+[tool.pytest.ini_options]
+addopts = "-q"
+testpaths = ["tests"]

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -1,0 +1,47 @@
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from card_creator.requirements import RequirementManager, extract_urls, merge_text
+
+
+def test_requirement_manager_collects_core_fields():
+    manager = RequirementManager()
+    q1 = manager.next_question()
+    assert "occasion" in q1.lower()
+    manager.ingest_answer("Birthday party")
+
+    q2 = manager.next_question()
+    assert "personal" in q2.lower() or "business" in q2.lower()
+    manager.ingest_answer("Personal card")
+
+    q3 = manager.next_question()
+    assert "size" in q3.lower()
+    manager.ingest_answer("5x7 inch")
+
+    assert manager.requirements.is_core_complete()
+    assert not manager.requirements.required_fields_missing()
+
+
+def test_urls_are_extracted_and_stored():
+    manager = RequirementManager()
+    manager.next_question()
+    manager.ingest_answer("Birthday with image https://example.com/pic.png")
+    assert "https://example.com/pic.png" in manager.requirements.image_urls
+    assert manager.requirements.occasion == "Birthday with image"
+
+
+def test_merge_text_adds_unique_segments():
+    assert merge_text(None, "A") == "A"
+    assert merge_text("A", "B") == "A; B"
+    assert merge_text("Include logo", "logo") == "Include logo"
+
+
+def test_extract_urls_handles_multiple_entries():
+    text = "Use https://one.example/img.jpg and also http://two.example/a.png"
+    urls = extract_urls(text)
+    assert urls == [
+        "https://one.example/img.jpg",
+        "http://two.example/a.png",
+    ]


### PR DESCRIPTION
## Summary
- add a rule-based interview flow and CLI to gather card requirements before triggering a CrewAI design blueprint
- integrate configuration utilities, Pexels background search, and a multi-agent crew that returns structured JSON output
- document setup steps and add automated tests for requirement parsing utilities

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd72d863cc8326a9554c43f74f9454