### PR TITLE
Show card preview image galleries and normalise URLs

### DIFF
--- a/tests/test_crew.py
+++ b/tests/test_crew.py
@@ -1,0 +1,78 @@
+from pathlib import Path
+import sys
+from textwrap import dedent
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from card_creator.crew import CardDesignCrew
+
+
+def _make_crew() -> CardDesignCrew:
+    crew = object.__new__(CardDesignCrew)
+    return crew  # type: ignore[return-value]
+
+
+def test_safe_parse_json_with_trailing_notes() -> None:
+    payload = dedent(
+        """
+        {
+          "card_summary": "A heartfelt invitation for Ambika's birthday party, designed to evoke emotions and encourage attendance from Narotam, a valued colleague.",
+          "messaging": {
+            "headline": "Join Us for a Special Celebration!",
+            "body": "Dear Narotam, we would be thrilled to have you at Ambika's birthday party! It's a day to celebrate joy, laughter, and wonderful memories. Your presence would mean the world to us.",
+            "closing": "Looking forward to celebrating together!"
+          },
+          "visual_direction": {
+            "palette": "Rich red tones to evoke warmth and excitement, complemented by soft floral accents.",
+            "typography": "Handwritten style for a personal touch, ensuring the text feels inviting and friendly.",
+            "layout": "Centered layout with the headline at the top, followed by the body text and closing at the bottom. Floral elements will frame the card edges.",
+            "background_image_plan": "The background will feature a soft-focus floral image to create a warm and inviting atmosphere, with the text overlaying in a contrasting color for readability."
+          },
+          "image_assets": {
+            "must_use": [
+              "https://reflect.webgarh.com/wp-content/uploads/2025/05/IMG-20240416-WA0009-e1747995653537-300x300.jpg"
+            ],
+            "pexels_options": [
+              "https://images.pexels.com/photos/20849554/pexels-photo-20849554.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=650&w=940"
+            ]
+          },
+          "production_notes": "Ensure high-quality printing with a matte finish to enhance the handwritten typography. Export in a format suitable for social media sharing.",
+          "next_questions": [
+            "What is the date and time of the birthday party?",
+            "What are the RSVP details?"
+          ]
+        }
+
+        Inspiring backgrounds from Pexels:
+        - https://images.pexels.com/photos/3873490/pexels-photo-3873490.jpeg
+        """
+    ).strip()
+
+    crew = _make_crew()
+    parsed = CardDesignCrew._safe_parse_json(crew, payload)
+
+    assert parsed is not None
+    assert parsed["card_summary"].startswith("A heartfelt invitation")
+
+
+def test_safe_parse_json_ignores_preceding_text() -> None:
+    payload = dedent(
+        """
+        Here is the requested blueprint:
+        ```json
+        {"card_summary": "Simple card", "messaging": {"headline": "Hi", "body": "Hello", "closing": "Bye"}}
+        ```
+        Let me know if you need anything else.
+        """
+    )
+
+    crew = _make_crew()
+    parsed = CardDesignCrew._safe_parse_json(crew, payload)
+
+    assert parsed is not None
+    assert parsed["messaging"]["headline"] == "Hi"
+
+
+def test_safe_parse_json_returns_none_when_absent() -> None:
+    crew = _make_crew()
+    assert CardDesignCrew._safe_parse_json(crew, "No JSON here") is None

--- a/tests/test_html_renderer.py
+++ b/tests/test_html_renderer.py
@@ -53,3 +53,20 @@ def test_blueprint_to_html_handles_missing_sections() -> None:
     assert "Simple Hello" in html
     assert "No production notes provided" in html
     assert "No outstanding questions" in html
+
+
+def test_blueprint_to_html_cleans_image_urls() -> None:
+    messy_url = "https://example.com/assets/IMG-20240416-WA000\n9-e1747995653537-300x300.jpg"
+    blueprint = {
+        "image_assets": {
+            "must_use": [messy_url],
+            "pexels_options": [
+                {"image_url": " https://images.example/pexels-photo-3873490.jpeg?auto=c\nompress "}
+            ],
+        }
+    }
+
+    html = blueprint_to_html(blueprint)
+
+    assert "https://example.com/assets/IMG-20240416-WA0009-e1747995653537-300x300.jpg" in html
+    assert "https://images.example/pexels-photo-3873490.jpeg?auto=compress" in html

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -24,6 +24,21 @@ def test_requirement_manager_collects_core_fields():
     assert not manager.requirements.required_fields_missing()
 
 
+def test_card_type_inferred_from_occasion_answer():
+    manager = RequirementManager()
+    assert "occasion" in manager.next_question().lower()
+
+    manager.ingest_answer("Personal invitation card for office team")
+
+    assert manager.requirements.card_type == "personal invitation"
+
+    next_prompt = manager.next_question()
+    assert "size" in next_prompt.lower()
+
+    # Ensure we have already skipped the explicit card type question
+    assert "personal card" not in next_prompt.lower()
+
+
 def test_urls_are_extracted_and_stored():
     manager = RequirementManager()
     manager.next_question()


### PR DESCRIPTION
## Summary
- normalise whitespace-ridden image URLs before rendering so remote assets load reliably
- surface both user-provided and Pexels imagery inside the HTML preview with clickable galleries
- cover newline-split URLs from language model output with a regression test

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd83abb750832683dc35412879b62f