### PR TITLE
Add LLM prompt builder for custom card HTML

### DIFF
--- a/card_creator/cli.py
+++ b/card_creator/cli.py
@@ -85,6 +85,14 @@ def chat() -> None:
             "\nIs HTML ko copy karke kisi .html file mein save karein aur browser mein khol kar card dekh sakte hain."
         )
 
+    html_prompt = result.get("html_generation_prompt")
+    if html_prompt:
+        console.print("\n[bold]OpenAI/LLM HTML prompt:[/bold]")
+        console.print(html_prompt)
+        console.print(
+            "\nIs prompt ko ChatGPT ya kisi bhi code-generation model mein paste karke bespoke card HTML banwa sakte hain."
+        )
+
     inspirations = result.get("pexels_images", [])
     if inspirations:
         console.print("\n[bold]Inspiring backgrounds from Pexels:[/bold]")

--- a/card_creator/crew.py
+++ b/card_creator/crew.py
@@ -12,6 +12,7 @@ from crewai.llm import LLM
 from .config import Settings
 from .html_renderer import blueprint_to_html
 from .pexels import PexelsPhoto, search_backgrounds
+from .prompts import build_card_html_prompt
 from .requirements import CardRequirements
 
 
@@ -138,12 +139,18 @@ class CardDesignCrew:
             if isinstance(blueprint, dict)
             else None
         )
+        html_prompt = (
+            build_card_html_prompt(blueprint)
+            if isinstance(blueprint, dict)
+            else None
+        )
 
         return {
             "raw_output": raw_output,
             "blueprint": blueprint,
             "pexels_images": inspirations,
             "html_preview": html_preview,
+            "html_generation_prompt": html_prompt,
         }
 
     def _ensure_textual_payload(self, payload: Any) -> str:
@@ -161,10 +168,76 @@ class CardDesignCrew:
         return str(payload)
 
     def _safe_parse_json(self, payload: str) -> dict[str, Any] | None:
-        try:
-            return json.loads(payload)
-        except (TypeError, json.JSONDecodeError):
+        """Best-effort JSON parser that tolerates surrounding chatter."""
+
+        if not payload:
             return None
+
+        payload = payload.strip()
+        if not payload:
+            return None
+
+        for candidate in self._iter_json_candidates(payload):
+            try:
+                parsed = json.loads(candidate)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(parsed, dict):
+                return parsed
+        return None
+
+    def _iter_json_candidates(self, payload: str) -> list[str]:
+        """Collect potential JSON snippets contained within the payload."""
+
+        candidates: list[str] = []
+
+        def collect_segment(start_char: str, end_char: str) -> None:
+            start = payload.find(start_char)
+            while start != -1:
+                segment = self._extract_balanced_segment(payload, start, start_char, end_char)
+                if segment:
+                    candidates.append(segment)
+                    return
+                start = payload.find(start_char, start + 1)
+
+        collect_segment("{", "}")
+        collect_segment("[", "]")
+
+        if not candidates:
+            candidates.append(payload)
+
+        return candidates
+
+    @staticmethod
+    def _extract_balanced_segment(message: str, start: int, opener: str, closer: str) -> str | None:
+        """Return the smallest substring with balanced braces starting at ``start``."""
+
+        depth = 0
+        in_string = False
+        escape = False
+        for index in range(start, len(message)):
+            char = message[index]
+            if in_string:
+                if escape:
+                    escape = False
+                elif char == "\\":
+                    escape = True
+                elif char == '"':
+                    in_string = False
+                continue
+
+            if char == '"':
+                in_string = True
+                continue
+
+            if char == opener:
+                depth += 1
+            elif char == closer:
+                depth -= 1
+                if depth == 0:
+                    return message[start : index + 1]
+
+        return None
 
 
 __all__ = ["CardDesignCrew"]

--- a/card_creator/prompts.py
+++ b/card_creator/prompts.py
@@ -1,0 +1,155 @@
+"""Helpers to craft prompts for downstream card generation models."""
+from __future__ import annotations
+
+from typing import Any, Mapping, Sequence
+
+
+def build_card_html_prompt(blueprint: Mapping[str, Any]) -> str:
+    """Compose a rich prompt for an LLM to render the card as HTML/CSS."""
+
+    summary = _text(blueprint.get("card_summary"))
+    messaging = blueprint.get("messaging") or {}
+    headline = _text(messaging.get("headline"))
+    body_copy = _text(messaging.get("body"))
+    closing = _text(messaging.get("closing"))
+
+    visual_direction = blueprint.get("visual_direction") or {}
+    palette = _as_list(visual_direction.get("palette"))
+    typography = _text(visual_direction.get("typography"))
+    layout = _text(visual_direction.get("layout"))
+    background_plan = _text(visual_direction.get("background_image_plan"))
+
+    image_assets = blueprint.get("image_assets") or {}
+    must_use_images = _collect_image_urls(image_assets.get("must_use"))
+    inspirational_images = _collect_image_urls(image_assets.get("pexels_options"))
+
+    production_notes = _as_list(blueprint.get("production_notes"))
+    next_questions = _as_list(blueprint.get("next_questions"))
+
+    lines: list[str] = [
+        "You are an expert HTML/CSS designer creating a single invitation or greeting card.",
+        "Produce a complete <html> document with inline <style> so the design renders standalone.",
+        "Do not include any JavaScript.",
+    ]
+
+    if summary:
+        lines.extend(["", "Design intent:", f"- {summary}"])
+
+    content_lines = []
+    if headline:
+        content_lines.append(f"Headline: {headline}")
+    if body_copy:
+        content_lines.append(f"Body: {body_copy}")
+    if closing:
+        content_lines.append(f"Closing: {closing}")
+    if content_lines:
+        lines.extend(["", "Card copy:"])
+        lines.extend(f"- {item}" for item in content_lines)
+
+    direction_lines = []
+    if palette:
+        direction_lines.append("Palette:")
+        direction_lines.extend(f"  - {color}" for color in palette)
+    if typography:
+        direction_lines.append(f"Typography: {typography}")
+    if layout:
+        direction_lines.append(f"Layout guidance: {layout}")
+    if background_plan:
+        direction_lines.append(f"Background plan: {background_plan}")
+    if direction_lines:
+        lines.extend(["", "Visual direction:"])
+        lines.extend(f"- {item}" for item in direction_lines)
+
+    imagery_lines = []
+    if must_use_images:
+        imagery_lines.append("Embed these user-provided images as hero/background assets:")
+        imagery_lines.extend(f"  - {url}" for url in must_use_images)
+    if inspirational_images:
+        imagery_lines.append("Optionally reference these Pexels inspirations for mood:")
+        imagery_lines.extend(f"  - {url}" for url in inspirational_images)
+    if imagery_lines:
+        lines.extend(["", "Imagery cues:"])
+        lines.extend(f"- {item}" for item in imagery_lines)
+
+    if production_notes:
+        lines.extend(["", "Production notes (honour in layout decisions):"])
+        lines.extend(f"- {note}" for note in production_notes)
+
+    if next_questions:
+        lines.extend(["", "Open questions from the brief (avoid guessing details):"])
+        lines.extend(f"- {question}" for question in next_questions)
+
+    lines.extend(
+        [
+            "",
+            "Accessibility and formatting requirements:",
+            "- Make text readable with sufficient contrast.",
+            "- Use semantic HTML structure with clearly separated sections.",
+            "- Keep the layout responsive for both desktop and mobile widths.",
+        ]
+    )
+
+    return "\n".join(lines).strip()
+
+
+def _text(value: Any) -> str:
+    if value is None:
+        return ""
+    return str(value).strip()
+
+
+def _as_list(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, (list, tuple, set)):
+        return [str(item).strip() for item in value if str(item).strip()]
+    text = _text(value)
+    if "\n" in text:
+        return [line.strip() for line in text.splitlines() if line.strip()]
+    if "," in text:
+        return [segment.strip() for segment in text.split(",") if segment.strip()]
+    return [text] if text else []
+
+
+def _collect_image_urls(candidate: Any) -> list[str]:
+    urls: list[str] = []
+    seen: set[str] = set()
+
+    def _append(url: str | None) -> None:
+        if url and url not in seen:
+            urls.append(url)
+            seen.add(url)
+
+    if candidate is None:
+        return urls
+
+    if isinstance(candidate, str):
+        _append(_normalise_url(candidate))
+        return urls
+
+    if isinstance(candidate, Mapping):
+        for key in ("image_url", "url", "src"):
+            value = candidate.get(key)
+            if isinstance(value, str):
+                _append(_normalise_url(value))
+        return urls
+
+    if isinstance(candidate, Sequence) and not isinstance(candidate, (str, bytes, bytearray)):
+        for item in candidate:
+            for url in _collect_image_urls(item):
+                _append(url)
+        return urls
+
+    _append(_normalise_url(str(candidate)))
+    return urls
+
+
+def _normalise_url(value: str) -> str | None:
+    stripped = value.strip()
+    if not stripped:
+        return None
+    collapsed = "".join(stripped.split())
+    return collapsed or None
+
+
+__all__ = ["build_card_html_prompt"]

--- a/tests/test_crew.py
+++ b/tests/test_crew.py
@@ -1,0 +1,78 @@
+from pathlib import Path
+import sys
+from textwrap import dedent
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from card_creator.crew import CardDesignCrew
+
+
+def _make_crew() -> CardDesignCrew:
+    crew = object.__new__(CardDesignCrew)
+    return crew  # type: ignore[return-value]
+
+
+def test_safe_parse_json_with_trailing_notes() -> None:
+    payload = dedent(
+        """
+        {
+          "card_summary": "A heartfelt invitation for Ambika's birthday party, designed to evoke emotions and encourage attendance from Narotam, a valued colleague.",
+          "messaging": {
+            "headline": "Join Us for a Special Celebration!",
+            "body": "Dear Narotam, we would be thrilled to have you at Ambika's birthday party! It's a day to celebrate joy, laughter, and wonderful memories. Your presence would mean the world to us.",
+            "closing": "Looking forward to celebrating together!"
+          },
+          "visual_direction": {
+            "palette": "Rich red tones to evoke warmth and excitement, complemented by soft floral accents.",
+            "typography": "Handwritten style for a personal touch, ensuring the text feels inviting and friendly.",
+            "layout": "Centered layout with the headline at the top, followed by the body text and closing at the bottom. Floral elements will frame the card edges.",
+            "background_image_plan": "The background will feature a soft-focus floral image to create a warm and inviting atmosphere, with the text overlaying in a contrasting color for readability."
+          },
+          "image_assets": {
+            "must_use": [
+              "https://reflect.webgarh.com/wp-content/uploads/2025/05/IMG-20240416-WA0009-e1747995653537-300x300.jpg"
+            ],
+            "pexels_options": [
+              "https://images.pexels.com/photos/20849554/pexels-photo-20849554.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=650&w=940"
+            ]
+          },
+          "production_notes": "Ensure high-quality printing with a matte finish to enhance the handwritten typography. Export in a format suitable for social media sharing.",
+          "next_questions": [
+            "What is the date and time of the birthday party?",
+            "What are the RSVP details?"
+          ]
+        }
+
+        Inspiring backgrounds from Pexels:
+        - https://images.pexels.com/photos/3873490/pexels-photo-3873490.jpeg
+        """
+    ).strip()
+
+    crew = _make_crew()
+    parsed = CardDesignCrew._safe_parse_json(crew, payload)
+
+    assert parsed is not None
+    assert parsed["card_summary"].startswith("A heartfelt invitation")
+
+
+def test_safe_parse_json_ignores_preceding_text() -> None:
+    payload = dedent(
+        """
+        Here is the requested blueprint:
+        ```json
+        {"card_summary": "Simple card", "messaging": {"headline": "Hi", "body": "Hello", "closing": "Bye"}}
+        ```
+        Let me know if you need anything else.
+        """
+    )
+
+    crew = _make_crew()
+    parsed = CardDesignCrew._safe_parse_json(crew, payload)
+
+    assert parsed is not None
+    assert parsed["messaging"]["headline"] == "Hi"
+
+
+def test_safe_parse_json_returns_none_when_absent() -> None:
+    crew = _make_crew()
+    assert CardDesignCrew._safe_parse_json(crew, "No JSON here") is None

--- a/tests/test_html_renderer.py
+++ b/tests/test_html_renderer.py
@@ -53,3 +53,20 @@ def test_blueprint_to_html_handles_missing_sections() -> None:
     assert "Simple Hello" in html
     assert "No production notes provided" in html
     assert "No outstanding questions" in html
+
+
+def test_blueprint_to_html_cleans_image_urls() -> None:
+    messy_url = "https://example.com/assets/IMG-20240416-WA000\n9-e1747995653537-300x300.jpg"
+    blueprint = {
+        "image_assets": {
+            "must_use": [messy_url],
+            "pexels_options": [
+                {"image_url": " https://images.example/pexels-photo-3873490.jpeg?auto=c\nompress "}
+            ],
+        }
+    }
+
+    html = blueprint_to_html(blueprint)
+
+    assert "https://example.com/assets/IMG-20240416-WA0009-e1747995653537-300x300.jpg" in html
+    assert "https://images.example/pexels-photo-3873490.jpeg?auto=compress" in html

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -1,0 +1,50 @@
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from card_creator.prompts import build_card_html_prompt
+
+
+def test_build_card_html_prompt_includes_core_sections() -> None:
+    blueprint = {
+        "card_summary": "Elegant engagement announcement",
+        "messaging": {
+            "headline": "She said yes!",
+            "body": "Join us as we toast to a lifetime of love.",
+            "closing": "With love, Priya & Arjun",
+        },
+        "visual_direction": {
+            "palette": ["#D4AF37", "#F8EDEB"],
+            "typography": "Modern serif for headings with clean sans body",
+            "layout": "Split layout with photo on the left and copy on the right",
+            "background_image_plan": "Subtle glitter gradient with soft vignette",
+        },
+        "image_assets": {
+            "must_use": ["https://example.com/uploads/couple.jpg"],
+            "pexels_options": [
+                {
+                    "image_url": " https://images.pexels.com/photos/12345/pexels-photo.jpeg?auto=c\nompress ",
+                }
+            ],
+        },
+        "production_notes": ["Use foil-friendly colour choices"],
+        "next_questions": ["Confirm final RSVP date"],
+    }
+
+    prompt = build_card_html_prompt(blueprint)
+
+    assert "Elegant engagement announcement" in prompt
+    assert "Headline: She said yes!" in prompt
+    assert "-   - #D4AF37" in prompt or "#D4AF37" in prompt
+    assert "https://example.com/uploads/couple.jpg" in prompt
+    assert "https://images.pexels.com/photos/12345/pexels-photo.jpeg?auto=compress" in prompt
+    assert "Use foil-friendly colour choices" in prompt
+    assert "Confirm final RSVP date" in prompt
+    assert "Do not include any JavaScript." in prompt
+
+
+def test_build_card_html_prompt_handles_minimal_blueprint() -> None:
+    prompt = build_card_html_prompt({})
+    assert "Do not include any JavaScript." in prompt
+    assert "Accessibility and formatting requirements" in prompt

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -24,6 +24,21 @@ def test_requirement_manager_collects_core_fields():
     assert not manager.requirements.required_fields_missing()
 
 
+def test_card_type_inferred_from_occasion_answer():
+    manager = RequirementManager()
+    assert "occasion" in manager.next_question().lower()
+
+    manager.ingest_answer("Personal invitation card for office team")
+
+    assert manager.requirements.card_type == "personal invitation"
+
+    next_prompt = manager.next_question()
+    assert "size" in next_prompt.lower()
+
+    # Ensure we have already skipped the explicit card type question
+    assert "personal card" not in next_prompt.lower()
+
+
 def test_urls_are_extracted_and_stored():
     manager = RequirementManager()
     manager.next_question()


### PR DESCRIPTION
## Summary
- add a prompt builder that turns a blueprint into an HTML/CSS design brief for downstream LLMs
- surface the generated prompt from the crew run and display it in the CLI so users can request bespoke layouts
- cover the new helper with regression tests to ensure copy, imagery and guidance are included

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd83abb750832683dc35412879b62f